### PR TITLE
Simplify MassType definitions

### DIFF
--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MassType.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/MassType.h
@@ -22,15 +22,13 @@
 #pragma once
 
 #include <sofa/core/config.h>
-#include <type_traits>
 
 namespace sofa::component::mass
 {
 
-template<typename T, typename = void>
+template<typename T>
 struct MassType
 {
-    using type = std::false_type;
 };
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/RigidMassType.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/RigidMassType.h
@@ -24,17 +24,14 @@
 #include <sofa/core/config.h>
 #include <sofa/defaulttype/RigidTypes.h>
 #include <SofaBaseMechanics/MassType.h>
-#include <type_traits>
 
 namespace sofa::component::mass
 {
 
-template<typename DataTypes> 
-struct MassType<DataTypes,
-                 std::enable_if_t < std::is_same_v<DataTypes, sofa::defaulttype::StdRigidTypes<DataTypes::spatial_dimensions, typename DataTypes::Real> > >
-> 
+template<sofa::Size N, typename real>
+struct MassType<sofa::defaulttype::StdRigidTypes<N, real> >
 {
-    using type = sofa::defaulttype::RigidMass< DataTypes::spatial_dimensions, typename DataTypes::Real>;
+    using type = sofa::defaulttype::RigidMass< N, real>;
 };
 
 

--- a/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/VecMassType.h
+++ b/SofaKernel/modules/SofaBaseMechanics/src/SofaBaseMechanics/VecMassType.h
@@ -29,12 +29,10 @@
 namespace sofa::component::mass
 {
 
-template<typename DataTypes>
-struct MassType<DataTypes,
-                std::enable_if_t < std::is_same_v<DataTypes, defaulttype::StdVectorTypes< type::Vec<DataTypes::spatial_dimensions, typename DataTypes::Real>, type::Vec<DataTypes::spatial_dimensions, typename DataTypes::Real>, typename DataTypes::Real > > >
->
+template<class TCoord, class TDeriv, class TReal>
+struct MassType<defaulttype::StdVectorTypes< TCoord, TDeriv, TReal> >
 {
-    using type = typename DataTypes::Real;
+    using type = TReal;
 };
 
 

--- a/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
+++ b/applications/plugins/SofaCUDA/sofa/gpu/cuda/CudaTypes.h
@@ -835,29 +835,16 @@ template<> struct DataTypeName<sofa::gpu::cuda::Vec3d1> { static const char* nam
 // define MassType for CudaTypes
 namespace sofa::component::mass
 {
-    template<typename DataTypes>
-    struct MassType<DataTypes,
-        std::enable_if_t < std::is_same_v<DataTypes, sofa::gpu::cuda::CudaVectorTypes< type::Vec<DataTypes::spatial_dimensions, typename DataTypes::Real>, type::Vec<DataTypes::spatial_dimensions, typename DataTypes::Real>, typename DataTypes::Real > > >
-    >
+    template<class TCoord, class TDeriv, class TReal>
+    struct MassType<sofa::gpu::cuda::CudaVectorTypes< TCoord, TDeriv, TReal> >
     {
-        using type = typename DataTypes::Real;
+        using type = TReal;
     };
 
-    template<typename DataTypes>
-    struct MassType<DataTypes,
-        std::enable_if_t < std::is_same_v<DataTypes, sofa::gpu::cuda::CudaVectorTypes< gpu::cuda::Vec3r1<typename DataTypes::Real>, gpu::cuda::Vec3r1<typename DataTypes::Real>, typename DataTypes::Real > > >
-    >
+    template<int N, typename real>
+    struct MassType<sofa::gpu::cuda::CudaRigidTypes<N, real> >
     {
-        using type = typename DataTypes::Real;
-    };
-
-
-    template<typename DataTypes>
-    struct MassType<DataTypes,
-        std::enable_if_t < std::is_same_v<DataTypes, sofa::gpu::cuda::CudaRigidTypes<DataTypes::spatial_dimensions, typename DataTypes::Real> > >
-    >
-    {
-        using type = sofa::defaulttype::RigidMass< DataTypes::spatial_dimensions, typename DataTypes::Real>;
+        using type = sofa::defaulttype::RigidMass<N, real>;
     };
 
 } // namespace sofa::component::mass


### PR DESCRIPTION
IMO, my proposition simplifies the definitions of `MassType`. It avoids the use of `enable_if`.

Also, the default `MassType` struct does not have any `type` alias. This is to fail the compilation if none of the "specialization" can be found.



______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
